### PR TITLE
Added String Input Unit Test+Fixed Formatting

### DIFF
--- a/frontend/src/components/__tests__/StringInput.spec.ts
+++ b/frontend/src/components/__tests__/StringInput.spec.ts
@@ -1,1 +1,48 @@
-// This is where a unit test would go, but haven't made one yet
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import StringInput from '../StringInput.vue'
+import axios from 'axios'
+
+vi.mock('axios', async () => {
+  const actualAxios = await vi.importActual<any>('axios')
+  return {
+    ...actualAxios,
+    default: {
+      post: vi.fn()
+    }
+  }
+})
+
+describe('StringInput.vue', () => {
+  let wrapper: VueWrapper<any>
+
+  beforeEach(() => {
+    wrapper = mount(StringInput)
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should display reversed string when API call is successful', async () => {
+    vi.mocked(axios.post).mockResolvedValueOnce({ data: { reversed_string: 'gnirtS' } })
+
+    wrapper.vm.userInput = 'String'
+    await wrapper.vm.sendString()
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.reversedString).toBe('gnirtS')
+    expect(wrapper.find('.text-green-500').text()).toContain('Reversed String: gnirtS')
+  })
+
+  it('should display error message when API call fails', async () => {
+    vi.mocked(axios.post).mockRejectedValueOnce(new Error('Network Error'))
+    await wrapper.vm.sendString()
+
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.errorMessage).toBe('Could not connect to the server.')
+    expect(wrapper.find('.text-red-500').text()).toContain(
+      'Error: Could not connect to the server.'
+    )
+  })
+})


### PR DESCRIPTION
This should hopefully help show how to mock API requests, as for Unit Tests, you shouldn't need to actually connect to a backend or database, but instead make a fake version of it, or "mock" it.

The reasoning is Unit Tests should only test that specific unit, and if you start to rely on other components/connections, those could be faulty, and the unit test could fail for reasons that is not the fault of the unit (which is a e2e/integration/functional test). By mocking the service, you 100% guarantee that the test failing, is because of the unit!